### PR TITLE
ctor of DefaultAzureCredential is private-package

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -48,7 +48,7 @@ The code to create a synchronous Key Vault `KeyClient` would be similar to the f
 ```java
 KeyClient client = new KeyClientBuilder()
         .endpoint(<your-vault-url>)
-        .credential(new DefaultAzureCredential())
+        .credential(new DefaultAzureCredentialBuilder().build())
         .buildClient();
 ```
 
@@ -57,7 +57,7 @@ Similarly, to create an asynchronous Key Vault `KeyAsyncClient`, do the followin
 ```java
 KeyAsyncClient client = new KeyClientBuilder()
         .endpoint(<your-vault-url>)
-        .credential(new DefaultAzureCredential())
+        .credential(new DefaultAzureCredentialBuilder().build())
         .buildAsyncClient();
 ```
 


### PR DESCRIPTION
So it appears that for now we had to go through the Builder.
https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/keyvault/azure-security-keyvault-keys#create-key-client

Ignore this if there is plan to have ctor of `DefaultAzureCredential` as public.